### PR TITLE
Fix typos in overrideProjectFindModel

### DIFF
--- a/lib/atom-codesearch.js
+++ b/lib/atom-codesearch.js
@@ -99,12 +99,12 @@ export default {
     },
 
     overrideProjectFindModel() {
-        const modelShoudldRerunSearch = this.projectFindView.model.shoudldRerunSearch.bind(this.projectFindView.model);
-        this.projectFindView.model.shoudldRerunSearch = (...args) => {
+        const modelShouldRerunSearch = this.projectFindView.model.shouldRerunSearch.bind(this.projectFindView.model);
+        this.projectFindView.model.shouldRerunSearch = (...args) => {
             if (this.prevScanWasWithCodeSearch !== this.isActive) {
                 return true;
             }
-            return modelShoudldRerunSearch(...args);
+            return modelShouldRerunSearch(...args);
         };
     },
 


### PR DESCRIPTION
I recently installed this package in Atom and it didn't seem to speed up my searches at all. When I enabled debugging I saw some error messages, and when I started poking around noticed these typos.

When I fixed them locally I think the package started working because my searches were much faster.