### PR TITLE
update to match current atom version

### DIFF
--- a/lib/search-instance.js
+++ b/lib/search-instance.js
@@ -220,7 +220,9 @@ class SearchInstance {
                         lineTextOffset: 0,
                         matchText: lineMatch[0],
                         range: [[row, lineMatch.index],
-                            [row, lineMatch.index + lineMatch[0].length]]
+                            [row, lineMatch.index + lineMatch[0].length]],
+                        leadingContextLines: [],
+                        trailingContextLines: [],
                     });
                 }
             } while (lineMatch);


### PR DESCRIPTION
atom code currently requires a list for leadingContextLines and trailingContext lines (which unfortunately google codesearch doesn't support). With these added, the plugin works again with current versions of atom.

fixes https://github.com/antelle/atom-codesearch/issues/3